### PR TITLE
adding code to handle duplicate layer names to add_raster()

### DIFF
--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -2397,6 +2397,15 @@ class Map(ipyleaflet.Map):
         if isinstance(source, np.ndarray) or isinstance(source, xr.DataArray):
             source = common.array_to_image(source, **array_args)
 
+        # handle duplicate input layer names.
+        if hasattr(self, 'cog_layer_dict'):
+            if layer_name in self.cog_layer_dict:
+                base_name = layer_name
+                suffix = 1
+                while f"{base_name}_{suffix}" in self.cog_layer_dict:
+                    suffix += 1
+                layer_name = f"{base_name}_{suffix}"
+
         tile_layer = common.get_local_tile_layer(
             source,
             indexes=indexes,


### PR DESCRIPTION
**Changes:**

1. **Current behaviour:**
If a user adds N different rasters (from different source) to a map with the same `layer_name` arg the last raster added will overwrite the previous raster layers in the `m.cog_layer_dict` even though N rasters are displayed on the map.

2. **Expected behaviour:** 
If a user adds N different rasters (from different source) to a map with the same `layer_name`, subsequent rasters added after the 1st raster will have their `layer_name` appended with a suffix to make that `layer_name` unique. This will avoid any layers being overwritten in `m.cog_layer_dict`.

**Examples:**

Raw map, created using:

```
m = leafmap.Map(center=[-22.17615, -51.253043], zoom=19, height="450px")
m.add_basemap("SATELLITE")
m.layers[-1].visible = False
m.add_raster('image.tif', layer_name="image")
```

<img width="546" alt="raw_map" src="https://github.com/user-attachments/assets/d969147d-57f7-417a-8ead-938e149e4f11" />


1. **Existing behaviour**:

If we add a raster layer taking the default `layer_name` = "Raster" using:

```
m.add_raster(source="masks.tif",
             colormap="tab20",
             nodata=0,
             opacity=0.7) 
```

we get the following `m.cog_layer_dict.keys`:

```
dict_keys(['image', 'Raster'])
```

and the map looks like:
<img width="527" alt="raw_with_1_mask" src="https://github.com/user-attachments/assets/591a81fe-c114-49fa-9198-ff3812131472" />

If we add a second raster with the same `layer_name` using:

```
m.add_raster(source="masks_dtrees2.tif",
             colormap="tab20",
             nodata=0,
             opacity=0.7)
```

Currently, the `m.cog_layer_dict.keys` will be:

```
dict_keys(['image', 'Raster'])
```

**Even though both rasters are displayed on the image** (this is to do with how the `localtileserver` handles the tiles):

<img width="511" alt="raw_with_2_masks" src="https://github.com/user-attachments/assets/adfadc20-d1ce-4744-bea7-fe2249542d42" />

1. **New behaviour**:

After adding the two rasters with the same name, the `m.cog_layer_dict.keys` will be:

```
dict_keys(['image', 'Raster', 'Raster_1'])
```


**Changes:**

* added the following code snippet to `add_raster()`:

```
        # handle duplicate input layer names.
        if hasattr(self, 'cog_layer_dict'):
            if layer_name in self.cog_layer_dict:
                base_name = layer_name
                suffix = 1
                while f"{base_name}_{suffix}" in self.cog_layer_dict:
                    suffix += 1
                layer_name = f"{base_name}_{suffix}"
```

The code simply runs a counter that adds an integer suffix to the `layer_name` until its unique.